### PR TITLE
add numpy_include to mise_module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ mise_module = Extension(
     sources=[
         'utils/libmise/mise.pyx'
     ],
+    include_dirs=[numpy_include_dir]
 )
 
 


### PR DESCRIPTION
Fix for numpy/arrayobject.h: No such file or directory